### PR TITLE
Lint toml template

### DIFF
--- a/.github/actions/lint-toml-template/action.yml
+++ b/.github/actions/lint-toml-template/action.yml
@@ -1,0 +1,16 @@
+name: "Lint Toml Files"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.RUST_VERSION }}
+    - name: Install Cargo.toml linter
+      uses: baptiste0928/cargo-install@v1
+      with:
+        crate: cargo-sort
+        version: '1.0.9'
+    - name: Run Cargo.toml sort check
+      run: cargo sort -w --check

--- a/.github/actions/lint-toml-template/action.yml
+++ b/.github/actions/lint-toml-template/action.yml
@@ -1,9 +1,9 @@
-name: "Lint Toml Files"
+name: "Lint Toml"
+description: "Lints Toml Files"
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ env.RUST_VERSION }}

--- a/.github/actions/lint-toml-template/action.yml
+++ b/.github/actions/lint-toml-template/action.yml
@@ -1,5 +1,5 @@
-name: "Lint Toml"
-description: "Lints Toml Files"
+name: 'Lint Toml'
+description: 'Lints Toml Files'
 
 runs:
   using: "composite"
@@ -14,3 +14,4 @@ runs:
         version: '1.0.9'
     - name: Run Cargo.toml sort check
       run: cargo sort -w --check
+      shell: bash


### PR DESCRIPTION
Composite action for linting toml files.

Tested usage: https://github.com/FuelLabs/fuel-core/actions/runs/4202184846/jobs/7290145249

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/125060083/219688739-2a580d79-c864-4ea1-a081-94629c97d0bc.png">


From: https://github.com/FuelLabs/fuel-core/blob/use-lint-toml-template/.github/workflows/ci.yml

<img width="946" alt="image" src="https://user-images.githubusercontent.com/125060083/219684973-b7fd9fa1-f925-4eb4-8e46-3a3f78098890.png">

If this pattern for composite actions looks good, I'll implement a reusable action for notify-slack to cut down on duplicate code in ci.yml



